### PR TITLE
Updated download.php to use rawurlencode

### DIFF
--- a/includes/download.php
+++ b/includes/download.php
@@ -51,7 +51,7 @@ function dc_send_download_headers() {
 				if ( dc_xsendfile_enabled() ) {
 					header( 'X-Sendfile: ' . dc_file_location() . $release->filename );
 					header( 'Content-Type: application/octet-stream' );
-					header( 'Content-Disposition: attachment; filename=\"' . urlencode ( $release->filename ) . '\"' );
+					header( 'Content-Disposition: attachment; filename=\"' . rawurlencode ( $release->filename ) . '\"' );
 					exit;
 				}
 				
@@ -69,11 +69,11 @@ function dc_send_download_headers() {
 				// Content disposition
 				if ( strpos ( $_SERVER [ 'HTTP_USER_AGENT' ], "MSIE" ) > 0 )
 				{
-					header( 'Content-Disposition: attachment; filename="' . urlencode ( $release->filename ) . '"' );
+					header( 'Content-Disposition: attachment; filename="' . rawurlencode ( $release->filename ) . '"' );
 				}
 				else
 				{
-					header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . urlencode ( $release->filename ) );
+					header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode ( $release->filename ) );
 				}
 				
 				// Content type


### PR DESCRIPTION
At the time being download.php uses php's urlencode, however this uses an older version of encoding, which results in spaces being replaced with '+'. I propose we switch to using rawurlencode instead, which will encode spaces as '%20', which will leave the spaces untouched in the zip files during download.