### PR TITLE
Fix PHP 7.2+ notice

### DIFF
--- a/includes/helpers/string.php
+++ b/includes/helpers/string.php
@@ -37,16 +37,16 @@ function rand_str( $length = 32, $chars = '' ){
     $chars_length = (strlen($chars) - 1);
 
     // Start our string
-    $string = $chars{rand(0, $chars_length)};
+    $string = $chars[rand(0, $chars_length)];
    
     // Generate random string
     for ($i = 1; $i < $length; $i = strlen($string))
     {
         // Grab a random character from our list
-        $r = $chars{rand(0, $chars_length)};
+        $r = $chars[rand(0, $chars_length)];
        
         // Make sure the same two characters don't appear next to each other
-        if ($r != $string{$i - 1}) $string .=  $r;
+        if ($r != $string[$i - 1]) $string .=  $r;
     }
    
     // Return the string


### PR DESCRIPTION
Starting in PHP 7.2, "Array and string offset access syntax with curly braces is deprecated". This patch fixes this by replacing curly braces with brackets.
GitHub also normalized line breaks.